### PR TITLE
Move .bind(this) call to constructor in a few components

### DIFF
--- a/src/components/DownloadButton.js
+++ b/src/components/DownloadButton.js
@@ -1,6 +1,10 @@
 import React from 'react'
 
 export default class DownloadButton extends React.Component {
+  constructor() {
+    super()
+    this.onClick = this.onClick.bind(this)
+  }
 
   onClick(e) {
     this.props.onClick(e)
@@ -9,7 +13,7 @@ export default class DownloadButton extends React.Component {
   render() {
     return <button
       className="download-button"
-      onClick={this.onClick.bind(this)}>
+      onClick={this.onClick}>
       Download
     </button>
   }

--- a/src/components/DownloadPage.js
+++ b/src/components/DownloadPage.js
@@ -17,6 +17,8 @@ export default class DownloadPage extends React.Component {
     this._onChange = () => {
       this.setState(DownloadStore.getState())
     }
+
+    this.downloadFile = this.downloadFile.bind(this)
   }
 
   componentDidMount() {
@@ -43,7 +45,7 @@ export default class DownloadPage extends React.Component {
 
           <ChromeNotice />
           <p className="notice">Peers: {this.state.peers} &middot; Up: {formatSize(this.state.speedUp)} &middot; Down: {formatSize(this.state.speedDown)}</p>
-          <DownloadButton onClick={this.downloadFile.bind(this)} />
+          <DownloadButton onClick={this.downloadFile} />
 
         </div>
 

--- a/src/components/DropZone.js
+++ b/src/components/DropZone.js
@@ -5,6 +5,11 @@ export default class DropZone extends React.Component {
   constructor() {
     super()
     this.state = { focus: false }
+
+    this.onDragEnter = this.onDragEnter.bind(this)
+    this.onDragLeave = this.onDragLeave.bind(this)
+    this.onDragOver = this.onDragOver.bind(this)
+    this.onDrop = this.onDrop.bind(this)
   }
 
   onDragEnter() {
@@ -31,10 +36,10 @@ export default class DropZone extends React.Component {
 
   render() {
     return <div className="drop-zone" ref="root"
-      onDragEnter={this.onDragEnter.bind(this)}
-      onDragLeave={this.onDragLeave.bind(this)}
-      onDragOver={this.onDragOver.bind(this)}
-      onDrop={this.onDrop.bind(this)}>
+      onDragEnter={this.onDragEnter}
+      onDragLeave={this.onDragLeave}
+      onDragOver={this.onDragOver}
+      onDrop={this.onDrop}>
 
       <div className="drop-zone-overlay"
         hidden={!this.state.focus}

--- a/src/components/Tempalink.js
+++ b/src/components/Tempalink.js
@@ -1,6 +1,10 @@
 import React from 'react'
 
 export default class Tempalink extends React.Component {
+  constructor() {
+    super()
+    this.onClick = this.onClick.bind(this)
+  }
 
   onClick() {
     this.refs.input.getDOMNode().setSelectionRange(0, 9999)
@@ -10,7 +14,7 @@ export default class Tempalink extends React.Component {
     var url = window.location.origin + '/' + this.props.token
     return <input
       className="tempalink"
-      onClick={this.onClick.bind(this)}
+      onClick={this.onClick}
       readOnly
       ref="input"
       type="text"

--- a/src/components/UploadPage.js
+++ b/src/components/UploadPage.js
@@ -16,6 +16,8 @@ export default class UploadPage extends React.Component {
     this._onChange = () => {
       this.setState(UploadStore.getState())
     }
+
+    this.uploadFile = this.uploadFile.bind(this)
   }
 
   componentDidMount() {
@@ -25,7 +27,7 @@ export default class UploadPage extends React.Component {
   componentWillUnmount() {
     UploadStore.unlisten(this._onChange)
   }
-  
+
   uploadFile(file) {
     UploadActions.uploadFile(file)
   }
@@ -41,7 +43,7 @@ export default class UploadPage extends React.Component {
     switch (this.state.status) {
       case 'ready':
 
-        return <DropZone onDrop={this.uploadFile.bind(this)}>
+        return <DropZone onDrop={this.uploadFile}>
           <div className="page">
 
             <Spinner dir="up" />

--- a/src/components/Uploader.js
+++ b/src/components/Uploader.js
@@ -3,6 +3,10 @@ import React from 'react';
 import UploadActions from '@app/actions/UploadActions';
 
 export default class UploadPage extends React.Component {
+  constructor() {
+    super()
+    this.uploadFile = this.uploadFile.bind(this)
+  }
 
   uploadFile(file) {
     UploadActions.uploadFile(file);
@@ -12,7 +16,7 @@ export default class UploadPage extends React.Component {
     switch (this.props.status) {
       case 'ready':
         return <div>
-          <DropZone onDrop={this.uploadFile.bind(this)} />
+          <DropZone onDrop={this.uploadFile} />
           <Arrow dir="up" />
         </div>;
         break;


### PR DESCRIPTION
Moved binding event handlers to the constructor so they are only bound once for every instance of a class. This avoids calling .bind(this) every time a component needs to re-render. 

-Airbnb

> A bind call in the render path creates a brand new function on every single render. 

[Second code example in Airbnb style guide](https://github.com/airbnb/javascript/tree/master/react#methods)

[Also the second code example in react docs](https://facebook.github.io/react/docs/reusable-components.html#no-autobinding)
